### PR TITLE
[COOK-857] Modify unicorn.rb.erb template, quoting the port argument in ...

### DIFF
--- a/templates/default/unicorn.rb.erb
+++ b/templates/default/unicorn.rb.erb
@@ -5,7 +5,7 @@
 
 # What ports/sockets to listen on, and what options for them.
 <%- @listen.each do |port, options| %>
-listen <%= port %>, <%= options %>
+listen "<%= port %>", <%= options %>
 <%- end %>
 
 <%- if @working_directory %>


### PR DESCRIPTION
Quoting the port argument in the unicorn.rb template allows you to configure unicorn to listen on a socket. Example:

```
node.set[:unicorn][:port] = "/var/run/unicorn.sock"

unicorn_config "/etc/unicorn/#{app['id']}.rb" do
  listen({ node[:unicorn][:port] => node[:unicorn][:options] })
  working_directory ::File.join(app['deploy_to'], 'current')
  worker_timeout node[:unicorn][:worker_timeout] 
  preload_app node[:unicorn][:preload_app] 
  worker_processes node[:unicorn][:worker_processes]
  before_fork node[:unicorn][:before_fork] 
end
```
