### PR TITLE
[COOK-2442] Remove ActiveSupport method blank? from template

### DIFF
--- a/templates/default/unicorn.rb.erb
+++ b/templates/default/unicorn.rb.erb
@@ -5,7 +5,7 @@
 
 # What ports/sockets to listen on, and what options for them.
 <%- @listen.each do |port, options| %>
-listen "<%= port %>"<%- unless options.blank? %>, <%= options %><%- end %>
+listen "<%= port %>"<%- unless options.nil? or options.strip.empty? %>, <%= options %><%- end %>
 <%- end %>
 
 <%- if @working_directory %>


### PR DESCRIPTION
Remove the blank? method from the template since this is a method from
the ActiveSupport library and will create method missing exceptions if
its not available
