### PR TITLE
[COOK-2470] Add user directive support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ an application running under unicorn.
   4.
 * `unicorn_command_line` - If set, specifies the unicorn commandline to set
   in the config file.  Usefull when sandboxing your unicorn installation.
-* `user` - User and optional group to run children as. Default is nil.
+* `forked_user` - User to run children as. Default is nil.
+* `forked_group` - Group to run children as. You *must* specify a `forked_user`
+  as well to use this attribute. Default is nil.
 * `before_exec` - Default is nil.
 * `before_fork` - Default is nil.
 * `after_fork` - Default is nil.

--- a/templates/default/unicorn.rb.erb
+++ b/templates/default/unicorn.rb.erb
@@ -25,9 +25,9 @@ worker_processes <%= @worker_processes %>
 Unicorn::HttpServer::START_CTX[0] = "<%= @unicorn_command_line %>"
 <%- end %>
 
-<%- if @user %>
+<%- if @forked_user %>
 # Run forked children as specified user/group
-user <%= @user.join(", ") %>
+user "<%= @forked_user %>"<%= ", \"#{@forked_group}\"" unless @forked_group.nil? %>
 <%- end %>
 
 <%- if @before_exec %>


### PR DESCRIPTION
Add user support to the Unicorn cookbook to allow the child processes to run as an unprivileged user/group
