### PR TITLE
Pass default version into gem_package

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,6 @@
 #
 
 gem_package "unicorn" do
-  action :nstall
+  action :install
   version ">=0"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,4 +18,7 @@
 # limitations under the License.
 #
 
-gem_package "unicorn"
+gem_package "unicorn" do
+  action :nstall
+  version ">=0"
+end


### PR DESCRIPTION
Without it, gem_package will pass an empty version string to "gem install" which will fail.

➜ root@bao-test ~  /usr/bin/gem install ruby-shadow -q --no-rdoc --no-ri -v ""
ERROR:  While executing gem ... (ArgumentError)
    Illformed requirement [""]
➜ root@bao-test ~  /usr/bin/gem install ruby-shadow -q --no-rdoc --no-ri -v ">=0"
Building native extensions.  This could take a while...
Successfully installed ruby-shadow-2.3.3
1 gem installed
